### PR TITLE
Cost update

### DIFF
--- a/ontology/Cost.ttl
+++ b/ontology/Cost.ttl
@@ -1,4 +1,5 @@
 # imports: https://spec.edmcouncil.org/cdmc/ontology/Core
+# imports: https://spec.edmcouncil.org/cdmc/ontology/Lineage
 
 @prefix cdmc-core: <https://spec.edmcouncil.org/cdmc/ontology/Core/> .
 @prefix cdmc-cost: <https://spec.edmcouncil.org/cdmc/ontology/Cost/> .
@@ -14,7 +15,10 @@
 	dct:abstract "This ontology defines notions for determining costs of various cloud data management functions. " ;
 	dct:license "https://opensource.org/licenses/MIT"^^xsd:AnyURI ;
 	sm:copyright "Copyright (c) 2022 EDM Council, Inc." ;
-	owl:imports <https://spec.edmcouncil.org/cdmc/ontology/Core> ;
+	owl:imports
+		<https://spec.edmcouncil.org/cdmc/ontology/Core> ,
+		<https://spec.edmcouncil.org/cdmc/ontology/Lineage>
+		;
 	owl:versionInfo "Created with TopBraid Composer" ;
 	.
 
@@ -69,8 +73,28 @@ cdmc-cost:incurs
 	a owl:ObjectProperty ;
 	rdfs:label "incurs" ;
 	rdfs:comment "The acquisition of a liability" ;
-	rdfs:domain [] ;
+	rdfs:domain _:blank4 ;
 	rdfs:isDefinedBy <https://spec.edmcouncil.org/cdmc/ontology/Core> ;
 	rdfs:range cdmc-cost:Cost ;
+	.
+
+_:blank1
+	rdf:first cdmc-core:DataService ;
+	rdf:rest rdf:nil ;
+	.
+
+_:blank2
+	rdf:first cdmc-core:DatabaseStorage ;
+	rdf:rest _:blank1 ;
+	.
+
+_:blank3
+	rdf:first <https://spec.edmcouncil.org/cdmc/ontology/Lineage/Activity> ;
+	rdf:rest _:blank2 ;
+	.
+
+_:blank4
+	a owl:Class ;
+	owl:unionOf _:blank3 ;
 	.
 


### PR DESCRIPTION
I discovered on my hard drive that one of the files had been missing the definition for its union; this is a change I had made on my hard drive, but failed to commit when I did the final submission last year (maybe having to do with the hand-off to Colin to fiil in the definitions)

I have merged the files (Cost.ttl, both versions) and am submitting again. 

